### PR TITLE
Rework and update the team page

### DIFF
--- a/public/team/index.html
+++ b/public/team/index.html
@@ -108,11 +108,11 @@ Invidious is a community maintained project, this page lists the main people who
 <h1>Past contributors</h1>
 <p><a href="https://github.com/omarroth">Omar Roth</a>: Original developer
 <br>
-<a href="https://github.com/saltycrys">saltycrys</a>: Major development
+<a href="https://github.com/saltycrys">saltycrys</a>: Major code contributions
 <br>
-<a href="https://github.com/leonklingele">leonklingele</a>: Development
+<a href="https://github.com/leonklingele">leonklingele</a>: Code contributions
 <br>
-<a href="https://github.com/matthewmcgarvey">Matthew McGarvey</a>: Major development
+<a href="https://github.com/matthewmcgarvey">Matthew McGarvey</a>: Major code contributions
 <br><br>
 And <a href="https://github.com/iv-org/invidious/graphs/contributors">more!</a>
 </p>

--- a/public/team/index.html
+++ b/public/team/index.html
@@ -77,36 +77,36 @@
 <h1>The Team</h1>
 <h2>Project managers:</h2>
 <p>
-<a href="https://github.com/TheFrenchGhosty">TheFrenchGhosty</a>: Creator of this website - Finances manager - Documentation manager
+<a href="https://github.com/TheFrenchGhosty">TheFrenchGhosty</a> (2019-Today): Project manager - Finances manager - Documentation manager - Creator of this website - System administrator
 <br>
-<a href="https://github.com/Perflyst">Perflyst</a>: Infrastructure manager
+<a href="https://github.com/Perflyst">Perflyst</a> (2019-Today): Project manager - Infrastructure manager - System administrator
 </p>
-<p class="text-muted">Both project managers have full access to everything related to the project (making the project <a href="https://en.wikipedia.org/wiki/Bus_factor">bus factor</a> resistant).</p>
+<p class="text-muted">Both project managers have full access to everything related to the project (including the cryptocurrency wallets) (making the project <a href="https://en.wikipedia.org/wiki/Bus_factor">bus factor</a> resistant).</p>
 <h2>Developers:</h2>
 <p>
-<a href="https://github.com/SamantazFox">Samantaz Fox</a>: Main developer - Main tester - Administrator of the test instance
+<a href="https://github.com/SamantazFox">Samantaz Fox</a> (2021-Today): Lead developer - Main tester - Administrator of the test instance
 <br>
-<a href="https://github.com/unixfox">unixfox</a> Secondary developer - Kubernetes manager - Documentation manager
+<a href="https://github.com/syeopite">syeopite</a> (2021, 2023-Today): Core developer
+<br>
+<a href="https://github.com/unixfox">unixfox</a> (2020-Today): Core developer - Kubernetes manager - Documentation manager
 </p>
+<br>
 <h1>Main contributors</h1>
 <p>
-<a href="https://github.com/matthewmcgarvey">Matthew McGarvey</a>: Development
+<a href="https://github.com/ChunkyProgrammer">ChunkyProgrammer</a>: Development
 <br>
-<a href="https://github.com/TiA4f8R">TiA4f8R</a>: Reverse engineering - Research
-<br>
-<a href="https://github.com/TeamNewPipe">The NewPipe team</a>: Reverse engineering - Research
+<a href="https://github.com/TeamNewPipe">The NewPipe team</a>, mainly <a href="https://github.com/AudricV">AudricV</a>: Reverse engineering - Research
 <br>
 <a href="https://github.com/yt-dlp">The yt-dlp team</a>: Reverse engineering - Research
 </p>
-<br>
 <h1>Past contributors</h1>
 <p><a href="https://github.com/omarroth">Omar Roth</a>: Original developer
 <br>
-<a href="https://github.com/syeopite">syeopite</a>: Was the second main developer in the team, until we lost complete contact with him
-<br>
-<a href="https://github.com/saltycrys">saltycrys</a>: Development
+<a href="https://github.com/saltycrys">saltycrys</a>: Major development
 <br>
 <a href="https://github.com/leonklingele">leonklingele</a>: Development
+<br>
+<a href="https://github.com/matthewmcgarvey">Matthew McGarvey</a>: Major development
 <br><br>
 And <a href="https://github.com/iv-org/invidious/graphs/contributors">more!</a>
 </p>

--- a/public/team/index.html
+++ b/public/team/index.html
@@ -75,6 +75,10 @@
 <div class="col-md-12 col-lg-10 col-xl-8">
 <article>
 <h1>The Team</h1>
+<p>
+Invidious is a community maintained project, this page lists the main people who work/worked on it.
+</p>
+
 <h2>Project managers:</h2>
 <p>
 <a href="https://github.com/TheFrenchGhosty">TheFrenchGhosty</a> (2019-Today): Project manager - Finances manager - Documentation manager - Creator of this website - System administrator
@@ -96,6 +100,8 @@
 <a href="https://github.com/ChunkyProgrammer">ChunkyProgrammer</a>: Development
 <br>
 <a href="https://github.com/TeamNewPipe">The NewPipe team</a>, mainly <a href="https://github.com/AudricV">AudricV</a>: Reverse engineering - Research
+<br>
+<a href="https://github.com/FreeTubeApp">The FreeTube team</a>, mainly <a href="https://github.com/absidue">Absidue</a>: Reverse engineering - Research
 <br>
 <a href="https://github.com/yt-dlp">The yt-dlp team</a>: Reverse engineering - Research
 </p>


### PR DESCRIPTION
- Add back @syeopite to the developers list
- Add the date of the first major contribution (usually a commit to the main repo) of the active "member"
- Update the roles of almost everyone
- Add a message that explains that invidious is community maintained
- TiA4f8R is now @AudricV
- Add @ChunkyProgrammer to the main contributors list
- Add the FreeTube team/Absidue to the main contributors list
- More !

Note: the role is still roughly based on what I know (reason why I'm the one with the most "role" since I know what I do), if you disagree with anything or think something is missing for you or someone else, feel free to post a comment. I also wrote that @SamantazFox is the "Lead developer" since... she kinda is, but again, if you disagree post a comment. 

Result:

![image](https://github.com/iv-org/invidious.io/assets/47571719/1443a1a5-13e8-4da1-9ca2-baf7e4d4664a)
