### PR TITLE
Rework and update the team page - Basic version

### DIFF
--- a/public/team/index.html
+++ b/public/team/index.html
@@ -75,38 +75,39 @@
 <div class="col-md-12 col-lg-10 col-xl-8">
 <article>
 <h1>The Team</h1>
-<h2>Project managers:</h2>
 <p>
-<a href="https://github.com/TheFrenchGhosty">TheFrenchGhosty</a>: Creator of this website - Finances manager - Documentation manager
-<br>
-<a href="https://github.com/Perflyst">Perflyst</a>: Infrastructure manager
+Invidious is a community maintained project, the following lists are the main people who work on it.
 </p>
-<p class="text-muted">Both project managers have full access to everything related to the project (making the project <a href="https://en.wikipedia.org/wiki/Bus_factor">bus factor</a> resistant).</p>
-<h2>Developers:</h2>
 <p>
-<a href="https://github.com/SamantazFox">Samantaz Fox</a>: Main developer - Main tester - Administrator of the test instance
+<a href="https://github.com/TheFrenchGhosty">TheFrenchGhosty</a>
 <br>
-<a href="https://github.com/unixfox">unixfox</a> Secondary developer - Kubernetes manager - Documentation manager
+<a href="https://github.com/Perflyst">Perflyst</a>
+<br>
+<a href="https://github.com/SamantazFox">Samantaz Fox</a>
+<br>
+<a href="https://github.com/unixfox">unixfox</a>
+<br>
+<a href="https://github.com/syeopite">syeopite</a>
 </p>
+<p class="text-muted">Both TheFrenchGhosty and Perflyst have full access to everything related to the project (including the cryptocurrency wallets) (making the project <a href="https://en.wikipedia.org/wiki/Bus_factor">bus factor</a> resistant).</p>
+<br>
 <h1>Main contributors</h1>
 <p>
-<a href="https://github.com/matthewmcgarvey">Matthew McGarvey</a>: Development
+<a href="https://github.com/TeamNewPipe">The NewPipe team</a>, mainly <a href="https://github.com/AudricV">AudricV</a>
 <br>
-<a href="https://github.com/TiA4f8R">TiA4f8R</a>: Reverse engineering - Research
+<a href="https://github.com/FreeTubeApp">The FreeTube team</a>, mainly <a href="https://github.com/absidue">Absidue</a> and <a href="https://github.com/ChunkyProgrammer">ChunkyProgrammer</a>
 <br>
-<a href="https://github.com/TeamNewPipe">The NewPipe team</a>: Reverse engineering - Research
-<br>
-<a href="https://github.com/yt-dlp">The yt-dlp team</a>: Reverse engineering - Research
+<a href="https://github.com/yt-dlp">The yt-dlp team</a>
 </p>
 <br>
 <h1>Past contributors</h1>
 <p><a href="https://github.com/omarroth">Omar Roth</a>: Original developer
 <br>
-<a href="https://github.com/syeopite">syeopite</a>: Was the second main developer in the team, until we lost complete contact with him
+<a href="https://github.com/saltycrys">saltycrys</a>
 <br>
-<a href="https://github.com/saltycrys">saltycrys</a>: Development
+<a href="https://github.com/leonklingele">leonklingele</a>
 <br>
-<a href="https://github.com/leonklingele">leonklingele</a>: Development
+<a href="https://github.com/matthewmcgarvey">Matthew McGarvey</a>
 <br><br>
 And <a href="https://github.com/iv-org/invidious/graphs/contributors">more!</a>
 </p>


### PR DESCRIPTION
Superseed  #72 after a poll was made internally:

![image](https://github.com/iv-org/invidious.io/assets/47571719/d67c5aa1-881b-4196-97b4-a1686cdd5e04)


\+

![image](https://github.com/iv-org/invidious.io/assets/47571719/90632f06-808e-40d7-b06d-031a91d88041)

Make the team page really basic, remove the roles at the requests of some "team" member.

- Add back @syeopite to the active list
- Add a message that explains that invidious is community maintained
- TiA4f8R is now @AudricV
- Add the FreeTube team/Absidue/ChunkyProgrammer to the main contributors list


Result:

![basic-team-page](https://github.com/iv-org/invidious.io/assets/47571719/aa83379e-8e07-4389-8a26-5f74f3010938)
